### PR TITLE
Add JSON file persistence for event files

### DIFF
--- a/annotations/src/main/java/module-info.java
+++ b/annotations/src/main/java/module-info.java
@@ -4,4 +4,6 @@ module org.spongepowered.eventimplgen.annotations {
     // This way we can still use the internal package, but not
     // to external developers.
     exports org.spongepowered.eventgen.annotations.internal to org.spongepowered.eventimplgen;
+
+    requires com.google.gson;
 }

--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,8 @@ dependencies {
 
     compileOnlyApi libs.jetbrainsAnnotations
 
+    api(libs.gson)
+
     // Tests
     testImplementation libs.assertj
     testImplementation libs.joor

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ checkerQual = "3.26.0"
 dagger = "2.52"
 errorprone = "2.28.0"
 junit = "5.10.2"
+gson = "2.8.8"
 
 [libraries]
 autoService-annotations = { module = "com.google.auto.service:auto-service-annotations", version.ref = "autoService" }
@@ -19,6 +20,7 @@ javapoet = { module = "io.soabase.java-composer:java-composer", version = "1.0" 
 jetbrainsAnnotations = { module = "org.jetbrains:annotations", version = "24.1.0"}
 jakartaInject = { module = "jakarta.inject:jakarta.inject-api", version = "2.0.1" }
 javaxInject = { module = "javax.inject:javax.inject", version = "1" }
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 
 # Tests
 assertj = { module = "org.assertj:assertj-core", version = "3.26.0" }

--- a/src/test/java/org/spongepowered/eventimplgen/processor/EventImplWriterTest.java
+++ b/src/test/java/org/spongepowered/eventimplgen/processor/EventImplWriterTest.java
@@ -1,0 +1,109 @@
+package org.spongepowered.eventimplgen.processor;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class EventImplWriterTest {
+
+    private EventImplWriter writer;
+    private Elements elements;
+    private FileWriter fileWriter;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        elements = mock(Elements.class);
+        fileWriter = mock(FileWriter.class);
+        writer = new EventImplWriter(
+                mock(Filer.class),
+                elements,
+                mock(PropertySorter.class),
+                Set.of(),
+                mock(EventGenOptions.class),
+                mock(FactoryInterfaceGenerator.class),
+                mock(ClassGenerator.class)
+        );
+    }
+
+    @Test
+    public void testSerializeFileList() throws IOException {
+        TypeElement element1 = mock(TypeElement.class);
+        TypeElement element2 = mock(TypeElement.class);
+        when(elements.getBinaryName(element1)).thenReturn(() -> "test.Element1");
+        when(elements.getBinaryName(element2)).thenReturn(() -> "test.Element2");
+
+        writer.allFoundProperties.put(element1, new EventData(List.of(), Set.of()));
+        writer.allFoundProperties.put(element2, new EventData(List.of(), Set.of()));
+
+        writer.serializeFileList();
+
+        Gson gson = new Gson();
+        List<String> expectedList = List.of("test.Element1", "test.Element2");
+        String expectedJson = gson.toJson(expectedList);
+
+        String actualJson = Files.readString(Paths.get("fileList.json"));
+        assertEquals(expectedJson, actualJson);
+    }
+
+    @Test
+    public void testDeserializeFileList() throws IOException {
+        Gson gson = new Gson();
+        List<String> expectedList = List.of("test.Element1", "test.Element2");
+        String json = gson.toJson(expectedList);
+        Files.writeString(Paths.get("fileList.json"), json);
+
+        List<String> actualList = writer.deserializeFileList();
+        assertEquals(expectedList, actualList);
+    }
+
+    @Test
+    public void testValidateFileList() throws IOException {
+        TypeElement element1 = mock(TypeElement.class);
+        TypeElement element2 = mock(TypeElement.class);
+        when(elements.getTypeElement("test.Element1")).thenReturn(element1);
+        when(elements.getTypeElement("test.Element2")).thenReturn(null);
+
+        Gson gson = new Gson();
+        List<String> fileList = List.of("test.Element1", "test.Element2");
+        String json = gson.toJson(fileList);
+        Files.writeString(Paths.get("fileList.json"), json);
+
+        writer.validateFileList();
+
+        assertEquals(0, writer.allFoundProperties.size());
+        assertEquals(0, writer.roundFoundProperties.size());
+        assertEquals(false, writer.classesWritten);
+    }
+
+    @Test
+    public void testReadFileList() throws IOException {
+        TypeElement element1 = mock(TypeElement.class);
+        when(elements.getTypeElement("test.Element1")).thenReturn(element1);
+
+        Gson gson = new Gson();
+        List<String> fileList = List.of("test.Element1");
+        String json = gson.toJson(fileList);
+        Files.writeString(Paths.get("fileList.json"), json);
+
+        writer.readFileList();
+
+        assertEquals(1, writer.allFoundProperties.size());
+        assertEquals(element1, writer.allFoundProperties.keySet().iterator().next());
+    }
+}

--- a/src/test/java/org/spongepowered/eventimplgen/processor/EventImplWriterTest.java
+++ b/src/test/java/org/spongepowered/eventimplgen/processor/EventImplWriterTest.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Event Implementation Generator, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.eventimplgen.processor;
 
 import com.google.gson.Gson;

--- a/test-data/src/test/java/test/event/TestEventFactoryTest.java
+++ b/test-data/src/test/java/test/event/TestEventFactoryTest.java
@@ -28,6 +28,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import test.event.lifecycle.NestedTest;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 
 class TestEventFactoryTest {
@@ -72,4 +75,14 @@ class TestEventFactoryTest {
         Assertions.assertNotNull(TestEventFactory.createInclusiveEvent(List.of(), false));
     }
 
+    @Test
+    void testJsonFileExists() throws IOException {
+        Assertions.assertTrue(Files.exists(Paths.get("fileList.json")));
+    }
+
+    @Test
+    void testJsonFileContents() throws IOException {
+        String jsonContent = Files.readString(Paths.get("fileList.json"));
+        Assertions.assertTrue(jsonContent.contains("test.event.lifecycle.NestedTest"));
+    }
 }


### PR DESCRIPTION
Add functionality to persist and read the list of files to/from a JSON file in `EventImplWriter`.

* Add methods to serialize and deserialize the list of files to/from a JSON file.
* Call the serialization method at the end of each scan and the deserialization method at the start of each scan.
* Validate if the existing files are still present and restart the file collection if files have been removed.
* Add unit tests in `EventImplWriterTest` to verify the output of the JSON file, including serialization, deserialization, and validation of the file list.
* Add tests in `TestEventFactoryTest` to assert the existence and contents of the output JSON file.

